### PR TITLE
feat #41: User가 즐겨찾기한 News를 조회, 추가 및 삭제할 수 있다.

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -20,12 +20,15 @@ const getTokensAndUserIdParsedFromBody = async (body: string) => {
   log.info('body', body);
   const accessToken = body['access_token'];
   const refreshToken = body['refresh_token'];
+  const newsId = body['news_id'];
   // TODO: 생각보다 컨트롤러가 비대한데... 책임을 분리할 방법은 없을까...
   const userId = (await getKakaoRawInfo(accessToken)).kakaoId;
+  log.debug(accessToken, refreshToken, newsId, userId);
   return {
     accessToken,
     refreshToken,
     userId,
+    newsId
   };
 };
 
@@ -208,11 +211,36 @@ export const getAllFavoriteNewsList = async (req: Request, res: Response) => {
   }
 };
 
+export const addFavoriteNews = async (req: Request, res: Response) => {
+  log.debug('addFavroiteNews Method Started')
+  const ids = await getTokensAndUserIdParsedFromBody(req.body);
+  const userId = ids.userId;
+  const newsId = ids.newsId;
+  try {
+    const favoriteNewsListWithUserId = await UserService.addNewFavoriteNews(userId, newsId);
+    log.debug(favoriteNewsListWithUserId)
+    res.status(StatusCode.OK).send({
+      status: StatusCode.OK,
+      message: favoriteNewsListWithUserId,
+    });
+  } catch (err) {
+    log.error(err);
+    res.status(err.code).send({
+      status: err.code,
+      message: {
+        favoriteNewsList: 'fail',
+        message: err.message,
+      },
+    });
+  }
+};
+
 export default {
   loginUserWithKakao,
   signUpUserWithKakao,
   logOutUserWithKakao,
   callbackKakao,
   refreshAccessToken,
-  getAllFavoriteNewsList
+  getAllFavoriteNewsList,
+  addFavoriteNews
 };

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -235,6 +235,30 @@ export const addFavoriteNews = async (req: Request, res: Response) => {
   }
 };
 
+export const removeFavoriteNews = async (req: Request, res: Response) => {
+  log.debug('addFavroiteNews Method Started')
+  const ids = await getTokensAndUserIdParsedFromBody(req.body);
+  const userId = ids.userId;
+  const newsId = ids.newsId;
+  try {
+    const favoriteNewsListWithUserId = await UserService.removeFavoriteNews(userId, newsId);
+    log.debug(favoriteNewsListWithUserId)
+    res.status(StatusCode.OK).send({
+      status: StatusCode.OK,
+      message: favoriteNewsListWithUserId,
+    });
+  } catch (err) {
+    log.error(err);
+    res.status(err.code).send({
+      status: err.code,
+      message: {
+        favoriteNewsList: 'fail',
+        message: err.message,
+      },
+    });
+  }
+}
+
 export default {
   loginUserWithKakao,
   signUpUserWithKakao,
@@ -242,5 +266,6 @@ export default {
   callbackKakao,
   refreshAccessToken,
   getAllFavoriteNewsList,
-  addFavoriteNews
+  addFavoriteNews,
+  removeFavoriteNews
 };

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -236,7 +236,7 @@ export const addFavoriteNews = async (req: Request, res: Response) => {
 };
 
 export const removeFavoriteNews = async (req: Request, res: Response) => {
-  log.debug('addFavroiteNews Method Started')
+  log.debug('addFavoriteNews Method Started')
   const ids = await getTokensAndUserIdParsedFromBody(req.body);
   const userId = ids.userId;
   const newsId = ids.newsId;

--- a/src/entity/News.ts
+++ b/src/entity/News.ts
@@ -3,10 +3,6 @@ import {
   Entity,
   PrimaryGeneratedColumn,
   Column,
-  CreateDateColumn,
-  UpdateDateColumn,
-  ManyToMany,
-  JoinTable,
   OneToMany,
 } from 'typeorm';
 import { Category } from '../shared/common/Category';
@@ -14,7 +10,6 @@ import { Gender } from '../shared/common/Gender';
 import { Time } from '../vo/Time';
 import { Suitability } from '../shared/common/Suitability';
 import { Tag } from './Tag';
-import { NewsInfo } from '../types';
 import { Channel } from '../shared/common/Channel';
 import { Script } from './Script';
 

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -44,37 +44,42 @@ export class User extends BaseEntity {
   @Column()
   gender: Gender;
 
-  @ManyToMany((type) => News)
+  @ManyToMany(() => News, { eager: false })
   @JoinTable({
     name: 'user_favorite_news',
     joinColumn: {
       name: 'user',
-      referencedColumnName: 'id',
+      referencedColumnName: 'kakaoId',
     },
     inverseJoinColumn: {
       name: 'news',
       referencedColumnName: 'id',
     },
   })
-  favoriteNews: News[];
+  favoriteNews: Promise<News[]>;
 
   @AfterLoad()
   async nullChecks() {
     const NO_EMAIL = "NO_EMAIL";
-    if (!this.favoriteNews) {
-      this.favoriteNews = [];
-    }
+    // if (!this.favoriteNews) {
+    //   this.favoriteNews = [];
+    // }
     if (!this.email) {
       log.info("User denied to provide email information")
       this.email = NO_EMAIL
     }
   }
 
-  public favoriteFreshNews = (news: News) => {
+  public addFavoriteNews = async (news: News) => {
     console.log('>>> favoriteNews ', this.favoriteNews);
-    this.favoriteNews.push(news);
+    const favoriteNewsList = await this.favoriteNews;
+    favoriteNewsList.push(news);
     return this;
   };
+
+  public getFavoriteNews = async () => {
+    return await this.favoriteNews;
+  }
 
   static fromKakaoRawInfo(kakaoRawInfo: KakaoRawInfo): User {
     return new User(kakaoRawInfo.kakaoId, kakaoRawInfo.nickname, kakaoRawInfo.email, Gender.UNSPECIFIED);

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -61,9 +61,6 @@ export class User extends BaseEntity {
   @AfterLoad()
   async nullChecks() {
     const NO_EMAIL = "NO_EMAIL";
-    // if (!this.favoriteNews) {
-    //   this.favoriteNews = [];
-    // }
     if (!this.email) {
       log.info("User denied to provide email information")
       this.email = NO_EMAIL
@@ -71,9 +68,16 @@ export class User extends BaseEntity {
   }
 
   public addFavoriteNews = async (news: News) => {
-    console.log('>>> favoriteNews ', this.favoriteNews);
     const favoriteNewsList = await this.favoriteNews;
     favoriteNewsList.push(news);
+    return this;
+  };
+
+  public removeFavoriteNews = async (toBeDeletedNews: News) => {
+    const favoriteNewsList = await this.favoriteNews;
+    this.favoriteNews = Promise.resolve(favoriteNewsList.filter((nowIteratedNews) => {
+      return nowIteratedNews.id !== toBeDeletedNews.id;
+    }));
     return this;
   };
 

--- a/src/repository/NewsRepository.ts
+++ b/src/repository/NewsRepository.ts
@@ -55,4 +55,8 @@ export class NewsQueryRepository extends Repository<News> {
       .where('news.id = :newsId', { newsId })
       .getOne();
   }
+
+  async findByNewsId(newsId: string) {
+    return this.createQueryBuilder('news').where('news.id = :newsId', { newsId }).getOneOrFail();
+  }
 }

--- a/src/repository/UserCommandRepository.ts
+++ b/src/repository/UserCommandRepository.ts
@@ -1,9 +1,14 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { User } from '../entity/User';
+import { Logger } from 'tslog';
+import UserNotFoundError from '../error/UserNotFoundError';
+
+const log: Logger = new Logger({ name: '딜리버블 백엔드 짱짱' });
 
 @EntityRepository(User)
 export class UserCommandRepository extends Repository<User> {
-  async registerNewUser(user: User): Promise<User> {
-    return await this.save(user);
+  async registerOrSaveUser(user: User): Promise<User> {
+    const newUser = this.create(user);
+    return this.save(newUser);
   }
 }

--- a/src/repository/UserQueryRepository.ts
+++ b/src/repository/UserQueryRepository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Repository } from 'typeorm';
+import { EntityRepository, getConnection, Repository } from 'typeorm';
 import { News } from '../entity/News';
 import { User } from '../entity/User';
 import { Logger } from 'tslog';
@@ -9,13 +9,27 @@ const log: Logger = new Logger({ name: '딜리버블 백엔드 짱짱' });
 export class UserQueryRepository extends Repository<User> {
   // id로 1개의 News 조회
   findByKakaoId(kakaoId: string) {
-    return this.createQueryBuilder('user')
-      .where('user.kakaoId = :kakaoId', { kakaoId })
-      .getOneOrFail();
+    return (
+      this.createQueryBuilder('user')
+        // .leftJoinAndSelect('user.favoriteNews', 'news')
+        .where('user.kakaoId = :kakaoId', { kakaoId })
+        .getOneOrFail()
+    );
   }
 
   findByEmail(email: string) {
     log.debug('email: ', email);
     return this.createQueryBuilder('user').where('user.email = :email', { email }).getOneOrFail();
+  }
+
+  async findByKakaoIdActiveRecordManner(kakaoId: string) {
+    const userRepository2 = await getConnection().getRepository(User);
+    const toBeUpdatedUser2 = await userRepository2.findOne({
+      where: {
+        kakaoId: kakaoId,
+      },
+      relations: ['favoriteNews'],
+    });
+    return toBeUpdatedUser2;
   }
 }

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -8,5 +8,6 @@ const FAVORITE = "/favorite";
 
 router.get(FAVORITE + '/all', errorHandler(UserController.getAllFavoriteNewsList));
 router.post(FAVORITE + '/add', errorHandler(UserController.addFavoriteNews));
+router.post(FAVORITE + '/remove', errorHandler(UserController.removeFavoriteNews));
 
 export default router;

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -7,7 +7,6 @@ const router: express.Router = Router();
 const FAVORITE = "/favorite";
 
 router.get(FAVORITE + '/all', errorHandler(UserController.getAllFavoriteNewsList));
-// router.get('/recommend', NewsController.recommendNews);
-// router.get('/detail/:newsId', NewsController.newsDetail);
+router.post(FAVORITE + '/add', errorHandler(UserController.addFavoriteNews));
 
 export default router;

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -1,0 +1,13 @@
+import express, { Router } from 'express';
+import UserController from "../controllers/UserController";
+import {errorHandler} from "../error/ErrorHandler";
+
+const router: express.Router = Router();
+
+const FAVORITE = "/favorite";
+
+router.get(FAVORITE + '/all', errorHandler(UserController.getAllFavoriteNewsList));
+// router.get('/recommend', NewsController.recommendNews);
+// router.get('/detail/:newsId', NewsController.newsDetail);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,10 +1,13 @@
 import { Router } from 'express';
 import NewsRouter from './NewsRouter';
 import kakaoRouter from './kakaoRouter';
+import UserRouter from "./UserRouter";
 
 const VERSION2 = '/v2';
 
 const router: Router = Router();
+
+router.use(VERSION2 + '/user', UserRouter);
 
 router.use(VERSION2 + '/news', NewsRouter);
 

--- a/src/service/NewsService.ts
+++ b/src/service/NewsService.ts
@@ -120,7 +120,7 @@ const searchByConditions = async (
   newsData = sortByDateAndTitle([newsData]);
   totalCount = newsData.length;
 
-  newsData = paginateWithOffsetAndLimit(searchCondition, newsData)
+  newsData = paginateWithOffsetAndLimit(searchCondition, newsData);
   return [newsData, totalCount];
 };
 
@@ -129,13 +129,17 @@ const searchRecommendNews = async () => {
   const newsRepository = await getConnectionToMySql();
   let newsData = await newsRepository.findRecommendNews();
   newsData = sortByDateAndTitle([newsData]);
-  return newsData.slice(0,recommendCount)
+  return newsData.slice(0, recommendCount);
 };
 
 const findNewsDetail = async (newsId: number) => {
   const newsRepository = await getConnectionToMySql();
-  let newsData = await newsRepository.findNewsDetail(newsId);
-  return newsData
+  return await newsRepository.findNewsDetail(newsId);
+};
+
+const searchByNewsId = async (newsId: string) => {
+  const newsRepository = await getConnectionToMySql();
+  return await newsRepository.findByNewsId(newsId);
 };
 
 export default {
@@ -146,4 +150,5 @@ export default {
   searchByConditions,
   searchRecommendNews,
   findNewsDetail,
+  searchByNewsId
 };

--- a/src/service/UserService.ts
+++ b/src/service/UserService.ts
@@ -4,7 +4,7 @@ import { UserQueryRepository } from '../repository/UserQueryRepository';
 import { isNotFoundUser, NotFoundUser } from '../entity/NotFoundUser';
 import { UserCommandRepository } from '../repository/UserCommandRepository';
 import UserNotFoundError from '../error/UserNotFoundError';
-import { KakaoRawInfo, UpdatedAccessTokenDTO } from '../types';
+import {KakaoRawInfo, UpdatedAccessTokenDTO, UserFavoriteNewsReturnDTO} from '../types';
 import axios from 'axios';
 import {
   ACCESS_TOKEN_INFO,
@@ -216,6 +216,14 @@ const saveRefreshTokenAtRedisMappedByUserId = async (
   return;
 };
 
+export const getAllFavoriteNewsList = async (userId: string): Promise<UserFavoriteNewsReturnDTO> => {
+  const user = await findUserByKakaoId(userId);
+  return {
+    kakaoId: user.kakaoId,
+    favoriteNews: user.favoriteNews,
+  }
+}
+
 export default {
   loginUserWithKakao,
   signUpUserWithKakao,
@@ -226,4 +234,5 @@ export default {
   checkAccessTokenExpirySeconds,
   saveRefreshTokenAtRedisMappedByUserId,
   updateAccessTokenByRefreshToken,
+  getAllFavoriteNewsList
 };

--- a/src/service/UserService.ts
+++ b/src/service/UserService.ts
@@ -252,7 +252,16 @@ export const addNewFavoriteNews = async (kakaoId: string, newsId: string): Promi
   const pendingFavoriteNews = await NewsService.searchByNewsId(newsId);
   const toBeUpdatedUser2 = await userQueryRepository.findByKakaoIdActiveRecordManner(kakaoId);
 
-  await toBeUpdatedUser2.favoriteFreshNews(pendingFavoriteNews);
+  await toBeUpdatedUser2.addFavoriteNews(pendingFavoriteNews);
+  return await updateExistingUser(toBeUpdatedUser2);
+};
+
+export const removeFavoriteNews = async (kakaoId: string, newsId: string): Promise<UserInfo> => {
+  const userQueryRepository = await getConnectionToUserQueryRepository();
+  const toBeUpdatedUser = await userQueryRepository.findByKakaoIdActiveRecordManner(kakaoId);
+  const pendingRemovedNews = await NewsService.searchByNewsId(newsId);
+
+  const toBeUpdatedUser2 = await toBeUpdatedUser.removeFavoriteNews(pendingRemovedNews);
   return await updateExistingUser(toBeUpdatedUser2);
 };
 
@@ -268,4 +277,5 @@ export default {
   updateAccessTokenByRefreshToken,
   getAllFavoriteNewsList,
   addNewFavoriteNews,
+  removeFavoriteNews
 };

--- a/src/service/UserService.ts
+++ b/src/service/UserService.ts
@@ -258,11 +258,11 @@ export const addNewFavoriteNews = async (kakaoId: string, newsId: string): Promi
 
 export const removeFavoriteNews = async (kakaoId: string, newsId: string): Promise<UserInfo> => {
   const userQueryRepository = await getConnectionToUserQueryRepository();
-  const toBeUpdatedUser = await userQueryRepository.findByKakaoIdActiveRecordManner(kakaoId);
+  const toBeforeUpdatedUser = await userQueryRepository.findByKakaoIdActiveRecordManner(kakaoId);
   const pendingRemovedNews = await NewsService.searchByNewsId(newsId);
 
-  const toBeUpdatedUser2 = await toBeUpdatedUser.removeFavoriteNews(pendingRemovedNews);
-  return await updateExistingUser(toBeUpdatedUser2);
+  const toAfterUpdatedUser = await toBeforeUpdatedUser.removeFavoriteNews(pendingRemovedNews);
+  return await updateExistingUser(toAfterUpdatedUser);
 };
 
 export default {

--- a/src/service/UserService.ts
+++ b/src/service/UserService.ts
@@ -4,7 +4,7 @@ import { UserQueryRepository } from '../repository/UserQueryRepository';
 import { isNotFoundUser, NotFoundUser } from '../entity/NotFoundUser';
 import { UserCommandRepository } from '../repository/UserCommandRepository';
 import UserNotFoundError from '../error/UserNotFoundError';
-import {KakaoRawInfo, UpdatedAccessTokenDTO, UserFavoriteNewsReturnDTO} from '../types';
+import { KakaoRawInfo, UpdatedAccessTokenDTO, UserFavoriteNewsReturnDTO, UserInfo } from '../types';
 import axios from 'axios';
 import {
   ACCESS_TOKEN_INFO,
@@ -16,10 +16,12 @@ import {
 } from '../shared/AuthLink';
 import AccessTokenExpiredError from '../error/AccessTokenExpiredError';
 import { promisify } from 'util';
-const redisClient = require('../util/redis');
 import { Logger } from 'tslog';
 import AlreadyLoggedOutError from '../error/AlreadyLoggedOutError';
-import AlreadySignedUpError from "../error/AlreadySignedUpError";
+import AlreadySignedUpError from '../error/AlreadySignedUpError';
+import NewsService from './NewsService';
+
+const redisClient = require('../util/redis');
 
 const log: Logger = new Logger({ name: '딜리버블 백엔드 짱짱' });
 
@@ -37,11 +39,8 @@ const getConnectionToUserCommandRepository = async () => {
 export const findUserByKakaoId = async (kakaoId: string): Promise<User> => {
   const userQueryRepository = await getConnectionToUserQueryRepository();
   try {
-    const foundUser = await userQueryRepository.findByKakaoId(kakaoId);
-    log.debug(' >>>>>>>>> foundUser using kakaoId', foundUser);
-    return foundUser;
+    return await userQueryRepository.findByKakaoId(kakaoId);
   } catch (error) {
-    log.debug(' >>>>>>>>>>>> NotFoundUser using kakaoId');
     return new NotFoundUser();
   }
 };
@@ -168,18 +167,20 @@ const verifyUserAlreadyExistsByKakaoId = async (userId: string): Promise<void> =
   if (!isNotFoundUser(await findUserByKakaoId(userId))) {
     throw new AlreadySignedUpError();
   }
-}
+};
 
 // TODO: return user entity with wrapping object DTO
 export const signUpUserWithKakao = async (accessToken: string, userId: string): Promise<User> => {
   if (await doesAccessTokenExpire(accessToken)) {
     throw new AccessTokenExpiredError();
   }
+
   await verifyUserAlreadyExistsByKakaoId(userId);
   const kakaoRawInfo = await getKakaoRawInfo(accessToken);
   const newUser = User.fromKakaoRawInfo(kakaoRawInfo);
   const userCommandRepository = await getConnectionToUserCommandRepository();
-  return await userCommandRepository.registerNewUser(newUser);
+
+  return await userCommandRepository.registerOrSaveUser(newUser);
 };
 
 // TODO: refactor by splitting to AuthService from UserService
@@ -190,7 +191,6 @@ export const doesAccessTokenExists = async (accessToken: string): Promise<boolea
 };
 
 export const logOutUserWithKakao = async (_accessToken): Promise<string> => {
-  log.debug('HELLO >>>>>>>>>>>>>>>>>>>>>> ');
   if (await doesAccessTokenExists(_accessToken)) {
     throw new AlreadyLoggedOutError();
   }
@@ -216,13 +216,45 @@ const saveRefreshTokenAtRedisMappedByUserId = async (
   return;
 };
 
-export const getAllFavoriteNewsList = async (userId: string): Promise<UserFavoriteNewsReturnDTO> => {
-  const user = await findUserByKakaoId(userId);
+export const getAllFavoriteNewsList = async (
+  kakaoId: string,
+): Promise<UserFavoriteNewsReturnDTO> => {
+  const userQueryRepository = await getConnectionToUserQueryRepository();
+  const toBeUpdatedUser = await userQueryRepository.findByKakaoIdActiveRecordManner(kakaoId);
+  const favoriteNews = await toBeUpdatedUser.getFavoriteNews();
+
   return {
-    kakaoId: user.kakaoId,
-    favoriteNews: user.favoriteNews,
+    kakaoId: kakaoId,
+    favoriteNews: favoriteNews,
+  };
+};
+
+export const updateExistingUser = async (user: User): Promise<UserInfo> => {
+  const userQueryRepository = await getConnectionToUserQueryRepository();
+  const userCommandRepository = await getConnectionToUserCommandRepository();
+
+  try {
+    await userQueryRepository.findByKakaoId(user.kakaoId);
+  } catch {
+    throw new UserNotFoundError();
   }
-}
+
+  const returnUser = await userCommandRepository.registerOrSaveUser(user);
+  const returnUserFavoriteNews = await returnUser.favoriteNews;
+  const returnUserInfo = new UserInfo(returnUser);
+  returnUserInfo.addFavoriteNewsAfterPromiseResolved(returnUserFavoriteNews);
+
+  return returnUserInfo;
+};
+
+export const addNewFavoriteNews = async (kakaoId: string, newsId: string): Promise<UserInfo> => {
+  const userQueryRepository = await getConnectionToUserQueryRepository();
+  const pendingFavoriteNews = await NewsService.searchByNewsId(newsId);
+  const toBeUpdatedUser2 = await userQueryRepository.findByKakaoIdActiveRecordManner(kakaoId);
+
+  await toBeUpdatedUser2.favoriteFreshNews(pendingFavoriteNews);
+  return await updateExistingUser(toBeUpdatedUser2);
+};
 
 export default {
   loginUserWithKakao,
@@ -234,5 +266,6 @@ export default {
   checkAccessTokenExpirySeconds,
   saveRefreshTokenAtRedisMappedByUserId,
   updateAccessTokenByRefreshToken,
-  getAllFavoriteNewsList
+  getAllFavoriteNewsList,
+  addNewFavoriteNews,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,7 @@ export class KakaoRawInfo {
 
 export class UpdatedAccessTokenDTO {
   static NONE_TOKEN = 'NONE';
+
   constructor(
     _access_token: string,
     _expires_in: string,
@@ -114,6 +115,7 @@ export class UpdatedAccessTokenDTO {
       ? UpdatedAccessTokenDTO.NONE_TOKEN
       : _refresh_token_expires_in;
   }
+
   access_token: string;
   expires_in: string;
   // TODO: NONE이면 반환하지 않는 방법 고민해보기
@@ -126,4 +128,9 @@ export class UpdatedAccessTokenDTO {
       this.refresh_token_expires_in !== UpdatedAccessTokenDTO.NONE_TOKEN
     );
   }
+}
+
+export interface UserFavoriteNewsReturnDTO {
+  readonly kakaoId: string;
+  readonly favoriteNews: NewsInfo[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import { Time } from './vo/Time';
 import { Suitability } from './shared/common/Suitability';
 import { Tag } from './entity/Tag';
 import { Channel } from './shared/common/Channel';
+import { User } from './entity/User';
 
 export interface ConditionList {
   channels: boolean;
@@ -130,7 +131,27 @@ export class UpdatedAccessTokenDTO {
   }
 }
 
+export class UserInfo {
+  constructor(user: User) {
+    this.kakaoId = user.kakaoId;
+    this.nickname = user.nickname;
+    this.email = user.email;
+    this.gender = user.gender;
+  }
+  kakaoId: string;
+  nickname: string;
+  email: string;
+  gender: string;
+  favoriteNews?: NewsInfo[] | Promise<NewsInfo[]>;
+
+  addFavoriteNewsAfterPromiseResolved(_favoriteNews: NewsInfo[] | Promise<NewsInfo[]>) {
+    this.favoriteNews = _favoriteNews;
+    return this.favoriteNews;
+  }
+}
+
 export interface UserFavoriteNewsReturnDTO {
   readonly kakaoId: string;
-  readonly favoriteNews: NewsInfo[];
+  // EAGER LOADING | LAZY LOADING
+  readonly favoriteNews: NewsInfo[] | Promise<NewsInfo[]>;
 }

--- a/src/util/insertNews.ts
+++ b/src/util/insertNews.ts
@@ -8,6 +8,7 @@ import { Gender } from '../shared/common/Gender';
 import { Suitability } from '../shared/common/Suitability';
 import { NewsInfo } from '../types';
 import { Time } from '../vo/Time';
+import {Logger} from "tslog";
 
 // 추천 태그 생성
 let tagTestRecommend = new Tag();
@@ -219,13 +220,15 @@ tagTest14_2.name = '우주';
 let tagTest14_3 = new Tag();
 tagTest14_3.name = '누리호';
 
+const log: Logger = new Logger({ name: '딜리버블 백엔드 짱짱' });
+
 export const insertNewsData = async (connection) => {
   // await createConnection().then(async (connection) => {
 
     // drop tables
     const queryRunner = connection.createQueryRunner();
     await queryRunner.connect();
-    console.log("queryRunner executed")
+    log.info("queryRunner executed")
     // console.log(">>>>>>", await queryRunner.hasTable("tag"))
     // if (await queryRunner.hasTable("tag")) {
     //   await queryRunner.dropTable("tag")
@@ -564,7 +567,7 @@ export const insertNewsData = async (connection) => {
           id: news2[i].id,
         },
       });
-      console.log(news3);
+      log.debug(news3);
     }
 };
 // insertNewsData();

--- a/src/util/insertScript.ts
+++ b/src/util/insertScript.ts
@@ -1,9 +1,11 @@
 import { News } from "../entity/News";
 import { Script } from "../entity/Script";
 import { Time } from "../vo/Time";
+import {Logger} from "tslog";
+
+const log: Logger = new Logger({ name: '딜리버블 백엔드 짱짱' });
 
 // 뉴스 별 스크립트 생성
-
 
 export const insertScriptData = async (connection) => {
 
@@ -33,11 +35,11 @@ export const insertScriptData = async (connection) => {
             id: scripts[i].news_id,
           },
         });
-        console.log(scripts[i].news_id);
-        console.log(news);
+        log.debug(scripts[i].news_id);
+        log.debug(news);
         // console.log(scripts1[i].news_id)
         // console.log(scripts2[i].news_id)
-        console.log(scripts3);
+        log.debug(scripts3);
       }
   };
 


### PR DESCRIPTION
## 작업 내용
* TypeORM의 Lazy Initailzation 기능을 이용하기 위하여 User Entity 내부에 별도의 검증 로직과 DTO 타입을 정의하였다.

## 참고한 내용
* https://orkhan.gitbook.io/typeorm/docs/eager-and-lazy-relations
* https://github.com/typeorm/typeorm/blob/master/docs/select-query-builder.md

## 고민할 사항
* Note: if you came from other languages (Java, PHP, etc.) and are used to use lazy relations everywhere - be careful. Those languages aren't asynchronous and lazy loading is achieved different way, that's why you don't work with promises there. In JavaScript and Node.JS you have to use promises if you want to have lazy-loaded relations. This is non-standard technique and considered experimental in TypeORM. 뭔 소리지? Lazy 쓰지 말라는 것인가?