### PR TITLE
get API의 request body를 header, params로 수정한다 [#105]

### DIFF
--- a/src/controllers/HighlightController.ts
+++ b/src/controllers/HighlightController.ts
@@ -62,10 +62,13 @@ export const getHighlightByKakaoIdAndNewsId = async (
   req: Request,
   res: Response,
 ): Promise<void | Response> => {
-  const accessToken = req.body['access_token'];
-  let kakaoId = req.body['user_id'];
-  kakaoId = kakaoId.replace(/['"]+/g, '');
-  const newsId = req.body['news_id'];
+  // const accessToken = req.body['access_token'];
+  // let kakaoId = req.body['user_id'];
+  // kakaoId = kakaoId.replace(/['"]+/g, '');
+  // const newsId = req.body['news_id'];
+  const accessToken = req.header("access_token");
+  const kakaoId = req.header("user_id");
+  const newsId: number = Number(req.query.news_id);
   log.debug('hello', kakaoId, newsId);
 
   try {

--- a/src/controllers/SpacingController.ts
+++ b/src/controllers/SpacingController.ts
@@ -48,11 +48,13 @@ export const createSpacing = async (req: Request, res: Response): Promise<void |
 };
 
 export const getSpacing = async (req: Request, res: Response): Promise<void | Response> => {
-  const tokensAndUserId = await UserController.getTokensParsedFromBody(req.body);
-  const accessToken = tokensAndUserId.accessToken;
-  let kakaoId = tokensAndUserId.userId;
-  kakaoId = kakaoId.replace(/['"]+/g, '');
-  const newsId = req.body.news_id;
+  // const tokensAndUserId = await UserController.getTokensParsedFromBody(req.body);
+  // const accessToken = tokensAndUserId.accessToken;
+  // let kakaoId = tokensAndUserId.userId;
+  // kakaoId = kakaoId.replace(/['"]+/g, '');
+  const accessToken = req.header("access_token");
+  const kakaoId = req.header("user_id");
+  const newsId: number = Number(req.query.news_id);
   const getSpacing = new GetSpacing(accessToken, kakaoId, newsId);
 
   try {

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -333,11 +333,15 @@ const getAccessTokenAndUserIdByCode = async (req: Request, res: Response) => {
 // };
 
 export const getAllFavoriteNewsList = async (req: Request, res: Response) => {
-  log.debug(req.header('access_token'));
-  const tokensAndId = await getTokensAndUserIdParsedFromBody(req.body);
-  log.debug(tokensAndId);
-  const accessToken = tokensAndId.accessToken;
-  const kakaoId = tokensAndId.userId;
+  // const tokensAndId = await getTokensAndUserIdParsedFromBody(req.body);
+  // log.debug(tokensAndId);
+  // const accessToken = tokensAndId.accessToken;
+  log.debug('***** header *****', req.header);
+  log.debug('access token in header', req.header("access_token"));
+  const accessToken = req.header("access_token");
+  const kakaoId = req.header("user_id");
+  log.debug('type of accessToken', typeof accessToken);
+  log.debug('type of kakaoId', typeof kakaoId);
   try {
     const favoriteNewsListWithUserId = await UserService.getAllFavoriteNewsList(
       accessToken,


### PR DESCRIPTION
대상 API: favorite/all, spacing, highlight

access_token, user_id --> header,
news_id --> query string